### PR TITLE
Hardcode replica count to 1

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -10,7 +10,6 @@ The following table lists the configurable parameters of the GenAiDecoy chart an
 
 | Parameter                     | Description                                      | Default                          |
 |-------------------------------|--------------------------------------------------|----------------------------------|
-| `replicaCount`                | Number of replicas                               | `1`                              |
 | `imagereference`              | Image reference                                  | `crowsi/genaidecoy:0.1.0`        |
 | `containerPort`               | Container port                                   | `8000`                           |
 | `genAIApiKeyEnvVariableName`  | Environment variable name for GenAI API key      | `GENAI_API_KEY`                  |
@@ -21,11 +20,7 @@ The following table lists the configurable parameters of the GenAiDecoy chart an
 | `Pathprefix`                  | Path prefix                                      | `PathPrefix(`/api`)`             |
 | `priority`                    | Priority                                         | `2`                              |
 
-You can specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or `helm upgrade`. For example:
-
-```sh
-helm install genAiDecoyRelease genAiDecoyRepo/genAiDecoy --set replicaCount=2
-```
+You can specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or `helm upgrade`.
 
 Alternatively, you can provide a YAML file that specifies the values for the parameters when installing or upgrading the chart:
 

--- a/helm/genAIDecoy/templates/genaidecoy-pod.yaml
+++ b/helm/genAIDecoy/templates/genaidecoy-pod.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: {{.Values.genAIDecoyProtocol}}-genaidecoy
 spec:
-  replicas: {{.Values.replicaCount}}
+  replicas: 1
   selector:
     matchLabels:
       app: {{.Values.genAIDecoyProtocol}}-genaidecoy

--- a/helm/genAIDecoy/values.yaml
+++ b/helm/genAIDecoy/values.yaml
@@ -1,8 +1,5 @@
 # Default values for genAIDecoy.
 
-# Number of replicas for the GenAIDecoy deployment
-replicaCount: 1
-
 # Docker image reference for the container
 imagereference: "crowsi/genaidecoy:0.2.0" # If you refer to a private repository, make sure to also specify the value "imagePullSecret"
 


### PR DESCRIPTION
To prevent session management issues with multiple replicas, the replica count has been hardcoded to 1 in the Helm chart.

The `replicas` field in `helm/genAIDecoy/templates/genaidecoy-pod.yaml` is now set to 1. The `replicaCount` parameter has been removed from `helm/genAIDecoy/values.yaml`. The documentation in `helm/README.md` has been updated to remove any mention of the `replicaCount` parameter.